### PR TITLE
pin hapi version 20.x for compitibility reasons with older node ve…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "main":             "hello.js",
     "private":          true,
     "dependencies": {
-        "@hapi/hapi":   "*",
+        "@hapi/hapi":   "20.*",
         "yargs":        "*",
         "nunjucks":     "*"
     }


### PR DESCRIPTION
pin hapi version 20.x for compatibility reasons with older node versions.
Tested with
- node version 18
- node version 14
- node version 12 